### PR TITLE
docs: fix refs to menubar repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is a dedicated chat browser that only does one thing: help you quickly access **the full webapps** of ChatGPT, Claude 2, Perplexity, Bing and more **with a single keyboard shortcut (Cmd+Shift+G)**.
 
-![image](https://github.com/smol-ai/menubar/assets/6764957/90f4bab4-e406-4507-b37e-8c8d80d18f15)
+![image](https://github.com/smol-ai/GodMode/assets/6764957/90f4bab4-e406-4507-b37e-8c8d80d18f15)
 
 ([click for video](https://twitter.com/swyx/status/1692988634364871032))
 
@@ -48,16 +48,16 @@ Yes and no:
 | Local/GGML Models (via [OobaBooga](https://github.com/oobabooga/text-generation-webui)) | Requires Local Setup, see oobabooga docs                                                                                                                                 |
 | Phind                                                                                   | Developer focused chat (temporarily disabled)                                                                                                                            |
 | [OpenRouter](https://openrouter.ai)                                                     | Access GPT4, Claude, PaLM, and open source models                                                                                                                        |
-| OpenAssistant                                                                           | Coming Soon — [Submit a PR](https://github.com/smol-ai/menubar/issues/37)!                                                                                               |
+| OpenAssistant                                                                           | Coming Soon — [Submit a PR](https://github.com/smol-ai/GodMode/issues/37)!                                                                                               |
 | Claude 1                                                                                | Requires Beta Access                                                                                                                                                     |
-| ... What Else?                                                                          | [Submit a New Issue](https://github.com/smol-ai/menubar/issues)!                                                                                                         |
+| ... What Else?                                                                          | [Submit a New Issue](https://github.com/smol-ai/GodMode/issues)!                                                                                                         |
 
 ## Features and Usage
 
 - **Keyboard Shortcuts**:
 
   - Use `Cmd+Shift+G` for quick open and `Cmd+Enter` to submit.
-  - Customize these shortcuts (thanks [@davej](https://github.com/smol-ai/menubar/pull/85)!):
+  - Customize these shortcuts (thanks [@davej](https://github.com/smol-ai/GodMode/pull/85)!):
     - Quick Open
       - ![image](https://github.com/davej/smol-ai-menubar/assets/6764957/3a6d0a16-7f54-43e5-9060-ec7b2486d32d)
     - Submit can be toggled to use `Enter` (faster for quick chat replies) vs `Cmd+Enter` (easier to enter multiline prompts)
@@ -81,7 +81,7 @@ Yes and no:
 
   - Initial support for [oobabooga/text-generation-webui](https://github.com/oobabooga/text-generation-webui) has been added.
   - Users need to follow the process outlined in the text-generation-webui repository, including downloading models (e.g. [LLaMa-13B-GGML](https://huggingface.co/TheBloke/LLaMa-13B-GGML/blob/main/llama-13b.ggmlv3.q4_0.bin)).
-  - Run the model on `http://127.0.0.1:7860/` before running it inside of the smol menubar.
+  - Run the model on `http://127.0.0.1:7860/` before running it inside of the smol GodMode browser.
   - The UI only supports one kind of prompt template. Contributions are welcome to make the templating customizable (see the Oobabooga.js provider).
 
 - **Starting New Conversations**:
@@ -123,7 +123,7 @@ If you want to build from source, you will need to clone the repo and open the p
 
    ```bash
    git clone https://github.com/smol-ai/GodMode.git
-   cd menubar
+   cd GodMode
    npm install
    # On Windows, you may also need Squirrel - these are old instructions, we would love a Windows volunteer to verify
    # npm install electron-squirrel-startup


### PR DESCRIPTION
Not sure if this really matters given GH's redirecting, so happy to pull back on this. I think keeping the `cd GodMode` instruction in the README is valuable though.